### PR TITLE
feat: implement certificate rolling update with continuous monitoring

### DIFF
--- a/vendor/github.com/hwameistor/hwameistor/pkg/utils/certmanager/manager.go
+++ b/vendor/github.com/hwameistor/hwameistor/pkg/utils/certmanager/manager.go
@@ -81,7 +81,7 @@ func (m *certManager) GenerateSelfSignedCerts() (serverCertPEM *bytes.Buffer, se
 			Organization: m.Organizations,
 		},
 		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(1, 0, 0),
+		NotAfter:     time.Now().Add(m.EffectiveTime),
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/options.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/options.go
@@ -347,6 +347,11 @@ type ListOptions struct {
 	Raw *metav1.ListOptions
 }
 
+// ApplyToDeleteAllOf implements DeleteAllOfOption.
+func (o *ListOptions) ApplyToDeleteAllOf(*DeleteAllOfOptions) {
+	panic("unimplemented")
+}
+
 var _ ListOption = &ListOptions{}
 
 // ApplyToList implements ListOption for ListOptions.


### PR DESCRIPTION
Rolling update steps:

- clear the existing secret data to force regeneration
- recreate the AdmissionController Pod to pick up the new certs

You can check the updated cert expire time by:

```shell
kubectl get secret hwameistor-admission-ca -n hwameistor -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -dates
```

fix https://github.com/hwameistor/hwameistor-operator/issues/380