### PR TITLE
feat(operator): support Helm tolerations for local-disk-manager and local-storage

### DIFF
--- a/helm/operator/templates/hwameistorcluster.yaml
+++ b/helm/operator/templates/hwameistorcluster.yaml
@@ -50,6 +50,11 @@ spec:
       resources:
         {{- toYaml .Values.localDiskManager.manager.resources | nindent 8 }}
     tolerationOnMaster: {{ $.Values.localDiskManager.tolerationOnMaster }}
+    {{- with $.Values.localDiskManager.tolerations }}
+    common:
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
   localStorage:
     disable: {{ $.Values.localStorage.disable }}
     kubeletRootDir: {{ $.Values.localStorage.kubeletRootDir | quote }}
@@ -119,6 +124,11 @@ spec:
       hostPathSSHDir: {{ $.Values.localStorage.member.hostPathSSHDir }}
       hostPathDRBDDir: {{ $.Values.localStorage.member.hostPathDRBDDir }}
     tolerationOnMaster: {{ $.Values.localStorage.tolerationOnMaster }}
+    {{- with $.Values.localStorage.tolerations }}
+    common:
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     snapshot: 
       disable: {{ $.Values.localStorage.snapshot.disable }}
   scheduler:

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -14,6 +14,7 @@ operator:
  
 localDiskManager:
   tolerationOnMaster: true
+  tolerations: []
   kubeletRootDir: /var/lib/kubelet
   manager:
     imageRepository: hwameistor/local-disk-manager
@@ -34,6 +35,7 @@ localDiskManager:
 localStorage:
   disable: false
   tolerationOnMaster: true
+  tolerations: []
   kubeletRootDir: /var/lib/kubelet
   member:
     imageRepository: hwameistor/local-storage

--- a/pkg/install/localdiskmanager/localdiskmanager.go
+++ b/pkg/install/localdiskmanager/localdiskmanager.go
@@ -247,33 +247,37 @@ func SetLDMDaemonSet(clusterInstance *hwameistoriov1alpha1.Cluster) *appsv1.Daem
 	// setLDMDaemonSetContainers(clusterInstance)
 	ldmDaemonSetToCreate = setLDMDaemonSetContainers(newClusterInstance, ldmDaemonSetToCreate)
 
+	if newClusterInstance.Spec.LocalDiskManager.Common != nil && newClusterInstance.Spec.LocalDiskManager.Common.Tolerations != nil {
+		ldmDaemonSetToCreate.Spec.Template.Spec.Tolerations = append(ldmDaemonSetToCreate.Spec.Template.Spec.Tolerations, (*newClusterInstance.Spec.LocalDiskManager.Common.Tolerations)...)
+	}
+
 	if newClusterInstance.Spec.LocalDiskManager.TolerationOnMaster {
-		ldmDaemonSetToCreate.Spec.Template.Spec.Tolerations = []corev1.Toleration{
-			{
+		ldmDaemonSetToCreate.Spec.Template.Spec.Tolerations = append(ldmDaemonSetToCreate.Spec.Template.Spec.Tolerations,
+			corev1.Toleration{
 				Key:      "CriticalAddonsOnly",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node.kubernetes.io/not-ready",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node-role.kubernetes.io/master",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node-role.kubernetes.io/control-plane",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node.cloudprovider.kubernetes.io/uninitialized",
 				Operator: corev1.TolerationOpExists,
 			},
-		}
+		)
 	}
 
 	return ldmDaemonSetToCreate

--- a/pkg/install/localdiskmanager/localdiskmanager_test.go
+++ b/pkg/install/localdiskmanager/localdiskmanager_test.go
@@ -1,0 +1,76 @@
+package localdiskmanager
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	hwameistoriov1alpha1 "github.com/hwameistor/hwameistor-operator/api/v1alpha1"
+)
+
+func TestSetLDMDaemonSetUsesCommonTolerations(t *testing.T) {
+	cluster := &hwameistoriov1alpha1.Cluster{}
+	cluster.Spec.TargetNamespace = "hwameistor"
+	cluster.Spec.RBAC = &hwameistoriov1alpha1.RBACSpec{ServiceAccountName: "hwameistor-admin"}
+	cluster.Spec.LocalDiskManager = &hwameistoriov1alpha1.LocalDiskManagerSpec{
+		KubeletRootDir: "/var/lib/kubelet",
+		Common: &hwameistoriov1alpha1.PodCommonSpec{
+			Tolerations: &[]corev1.Toleration{{
+				Key:      "dedicated",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "storage",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+		},
+		Manager: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+		CSI: &hwameistoriov1alpha1.CSISpec{
+			Registrar: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+			Controller: &hwameistoriov1alpha1.CSIControllerSpec{
+				Provisioner: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+				Attacher:    &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+			},
+		},
+	}
+
+	daemonSet := SetLDMDaemonSet(cluster)
+	if len(daemonSet.Spec.Template.Spec.Tolerations) != 1 {
+		t.Fatalf("expected 1 toleration, got %d", len(daemonSet.Spec.Template.Spec.Tolerations))
+	}
+	if daemonSet.Spec.Template.Spec.Tolerations[0].Key != "dedicated" {
+		t.Fatalf("expected custom toleration to be propagated, got %#v", daemonSet.Spec.Template.Spec.Tolerations)
+	}
+}
+
+func TestSetLDMDaemonSetAppendsMasterTolerations(t *testing.T) {
+	cluster := &hwameistoriov1alpha1.Cluster{}
+	cluster.Spec.TargetNamespace = "hwameistor"
+	cluster.Spec.RBAC = &hwameistoriov1alpha1.RBACSpec{ServiceAccountName: "hwameistor-admin"}
+	cluster.Spec.LocalDiskManager = &hwameistoriov1alpha1.LocalDiskManagerSpec{
+		KubeletRootDir:     "/var/lib/kubelet",
+		TolerationOnMaster: true,
+		Common: &hwameistoriov1alpha1.PodCommonSpec{
+			Tolerations: &[]corev1.Toleration{{
+				Key:      "dedicated",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "storage",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+		},
+		Manager: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+		CSI: &hwameistoriov1alpha1.CSISpec{
+			Registrar: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+			Controller: &hwameistoriov1alpha1.CSIControllerSpec{
+				Provisioner: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+				Attacher:    &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+			},
+		},
+	}
+
+	daemonSet := SetLDMDaemonSet(cluster)
+	if len(daemonSet.Spec.Template.Spec.Tolerations) <= 1 {
+		t.Fatalf("expected custom + master tolerations, got %#v", daemonSet.Spec.Template.Spec.Tolerations)
+	}
+	if daemonSet.Spec.Template.Spec.Tolerations[0].Key != "dedicated" {
+		t.Fatalf("expected custom toleration first, got %#v", daemonSet.Spec.Template.Spec.Tolerations)
+	}
+}

--- a/pkg/install/localstorage/localstorage.go
+++ b/pkg/install/localstorage/localstorage.go
@@ -278,33 +278,37 @@ func SetLSDaemonSet(clusterInstance *hwameistoriov1alpha1.Cluster) *appsv1.Daemo
 	lsDaemonSetToCreate = setLSDaemonSetVolumes(clusterInstance, lsDaemonSetToCreate)
 	lsDaemonSetToCreate = setLSDaemonSetContainers(clusterInstance, lsDaemonSetToCreate)
 
+	if clusterInstance.Spec.LocalStorage.Common != nil && clusterInstance.Spec.LocalStorage.Common.Tolerations != nil {
+		lsDaemonSetToCreate.Spec.Template.Spec.Tolerations = append(lsDaemonSetToCreate.Spec.Template.Spec.Tolerations, (*clusterInstance.Spec.LocalStorage.Common.Tolerations)...)
+	}
+
 	if clusterInstance.Spec.LocalStorage.TolerationOnMaster {
-		lsDaemonSetToCreate.Spec.Template.Spec.Tolerations = []corev1.Toleration{
-			{
+		lsDaemonSetToCreate.Spec.Template.Spec.Tolerations = append(lsDaemonSetToCreate.Spec.Template.Spec.Tolerations,
+			corev1.Toleration{
 				Key:      "CriticalAddonsOnly",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node.kubernetes.io/not-ready",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node-role.kubernetes.io/master",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node-role.kubernetes.io/control-plane",
 				Operator: corev1.TolerationOpExists,
 			},
-			{
+			corev1.Toleration{
 				Effect:   corev1.TaintEffectNoSchedule,
 				Key:      "node.cloudprovider.kubernetes.io/uninitialized",
 				Operator: corev1.TolerationOpExists,
 			},
-		}
+		)
 	}
 
 	return lsDaemonSetToCreate

--- a/pkg/install/localstorage/localstorage_test.go
+++ b/pkg/install/localstorage/localstorage_test.go
@@ -1,0 +1,71 @@
+package localstorage
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	hwameistoriov1alpha1 "github.com/hwameistor/hwameistor-operator/api/v1alpha1"
+)
+
+func newLocalStorageSpec(tolerationOnMaster bool) *hwameistoriov1alpha1.LocalStorageSpec {
+	return &hwameistoriov1alpha1.LocalStorageSpec{
+		KubeletRootDir:     "/var/lib/kubelet",
+		TolerationOnMaster: tolerationOnMaster,
+		Common: &hwameistoriov1alpha1.PodCommonSpec{
+			Tolerations: &[]corev1.Toleration{{
+				Key:      "dedicated",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "storage",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+		},
+		Member: &hwameistoriov1alpha1.MemberSpec{
+			HostPathDRBDDir: "/etc/drbd.d",
+			HostPathSSHDir:  "/root/.ssh",
+			Image:           &hwameistoriov1alpha1.ImageSpec{},
+			JuicesyncImage:  &hwameistoriov1alpha1.ImageSpec{},
+		},
+		CSI: &hwameistoriov1alpha1.CSISpec{
+			Registrar: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+			Controller: &hwameistoriov1alpha1.CSIControllerSpec{
+				Provisioner:        &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+				Attacher:           &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+				Resizer:            &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+				Monitor:            &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+				SnapshotController: &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+				Snapshotter:        &hwameistoriov1alpha1.ContainerCommonSpec{Image: &hwameistoriov1alpha1.ImageSpec{}},
+			},
+		},
+	}
+}
+
+func TestSetLSDaemonSetUsesCommonTolerations(t *testing.T) {
+	cluster := &hwameistoriov1alpha1.Cluster{}
+	cluster.Spec.TargetNamespace = "hwameistor"
+	cluster.Spec.RBAC = &hwameistoriov1alpha1.RBACSpec{ServiceAccountName: "hwameistor-admin"}
+	cluster.Spec.LocalStorage = newLocalStorageSpec(false)
+
+	daemonSet := SetLSDaemonSet(cluster)
+	if len(daemonSet.Spec.Template.Spec.Tolerations) != 1 {
+		t.Fatalf("expected 1 toleration, got %d", len(daemonSet.Spec.Template.Spec.Tolerations))
+	}
+	if daemonSet.Spec.Template.Spec.Tolerations[0].Key != "dedicated" {
+		t.Fatalf("expected custom toleration to be propagated, got %#v", daemonSet.Spec.Template.Spec.Tolerations)
+	}
+}
+
+func TestSetLSDaemonSetAppendsMasterTolerations(t *testing.T) {
+	cluster := &hwameistoriov1alpha1.Cluster{}
+	cluster.Spec.TargetNamespace = "hwameistor"
+	cluster.Spec.RBAC = &hwameistoriov1alpha1.RBACSpec{ServiceAccountName: "hwameistor-admin"}
+	cluster.Spec.LocalStorage = newLocalStorageSpec(true)
+
+	daemonSet := SetLSDaemonSet(cluster)
+	if len(daemonSet.Spec.Template.Spec.Tolerations) <= 1 {
+		t.Fatalf("expected custom + master tolerations, got %#v", daemonSet.Spec.Template.Spec.Tolerations)
+	}
+	if daemonSet.Spec.Template.Spec.Tolerations[0].Key != "dedicated" {
+		t.Fatalf("expected custom toleration first, got %#v", daemonSet.Spec.Template.Spec.Tolerations)
+	}
+}


### PR DESCRIPTION
## Summary
- expose `localDiskManager.tolerations` and `localStorage.tolerations` in the Helm chart
- wire both fields into the generated `Cluster` CR
- apply the configured tolerations when reconciling the two DaemonSets
- keep existing `tolerationOnMaster` behavior and append those built-in tolerations
- add unit tests for both paths

## Why
Fixes #379.

The CRD already supports `common.tolerations`, but the Helm chart did not expose it for `local-disk-manager` and `local-storage`, and the installer paths did not apply those tolerations to the DaemonSets. As a result, user-defined tolerations could be lost on Helm upgrades.

## Validation
- `go test ./pkg/install/localdiskmanager ./pkg/install/localstorage`
- `helm template hwameistor-operator ./helm/operator`
